### PR TITLE
add: gradientStyle prop to <Gauge />

### DIFF
--- a/src/js/Gauge.js
+++ b/src/js/Gauge.js
@@ -38,6 +38,7 @@ const Gauge = (props) => {
     unfilledColor,
     circleColor,
     triangleTipColor,
+    gradientStyle,
   } = props;
 
   const prevCountRef = useRef();
@@ -147,6 +148,7 @@ const Gauge = (props) => {
             <LinearGradient
               colors={overallGradient}
               style={{
+                ...gradientStyle,
                 height: size,
                 width: size,
               }}
@@ -256,6 +258,7 @@ Gauge.defaultProps = {
   unfilledColor: 'grey',
   circleColor: 'blue',
   triangleTipColor: 'blue',
+  gradientStyle: {},
 };
 
 let styles;


### PR DESCRIPTION
Summary
-------

Adding a gradient style prop to allow editing of gradient if enabled. Also, I specifically spread [operator] the style over height and width, so any changes to height or width have no impact. This is because changing the height or width of the gradient breaks it.

Test Plan
---------

I tested this by transforming it with: 
```
gradientStyle={{
    transform: [{ rotateZ: "45deg" }],
}}. 
```
Also, it passed all checks. 

Also, this can only be tested once because I'm you and you're me, we can only check it once because we're the same person. 

Also, you're awesome.

Thank you.

Also, this is a re-merge after a reset. See: #4 